### PR TITLE
Exhibit 53

### DIFF
--- a/src/components/yith/Figure.js
+++ b/src/components/yith/Figure.js
@@ -23,9 +23,14 @@ class Figure extends Component {
       region = this.props.region
     }
 
+    if (manifest.summary.en !== null) {
+      this.setState({
+        summary: manifest.summary.en[0]
+      })
+    }
+
     this.setState({
       label: manifest.label.en[0],
-      summary: manifest.summary.en[0],
       requiredStatementLabel: manifest.requiredStatement.label.en[0],
       requiredStatementValue: manifest.requiredStatement.value.en[0],
       media: manifest.items[0].items[0].items[0].body[0].service['@id'] + '/' + region + '/!640,640/0/default.jpg'

--- a/src/pages/galston/music-pedagogy.js
+++ b/src/pages/galston/music-pedagogy.js
@@ -10,7 +10,7 @@ const StudienbuchPage = () => (
     <Seo title="Guided Tour" />
     <h1>Significance of the book in music pedagogy</h1>
     <section className="exhibits-section">
-      <div>
+      <div className="gift-to-musicians">
         <h2>Gift to musicians</h2>
         <p>Galston’s musical interpretations established the young pianist as one of the most gifted and sensitive interpreters of his day, but his gift to the musical world during this time was not limited to his inspired interpretations. In the spirit of scholarship and a willingness to share his musical ideas with future generations of pianists, Galston published his journey through his interpretative processes by analyzing the composers’ texts to capture, as one reviewer put it, the true character of each work. Therein lies the birth of Studienbuch, Galston's unparalleled gift to musicians and pedagogues for generations to come. </p>
       </div>
@@ -47,8 +47,8 @@ const StudienbuchPage = () => (
       </div>
     </Yith>
       </div>
-      <div>
-        <h2>Musicial interpretation</h2>
+      <div className="musical-interpretation">
+        <h2>Musical interpretation</h2>
         <p>In the foreword to Galston’s Studienbuch, the author describes the musical journey every interpreter takes when learning a new work. He explains how “every thoughtful artist experiences a whole world of emotions, forms perceptions and makes decisions, finds and defines the points of attack, discovers hidden pivotal points around which the entire work turns, secretly identifies the treacherous spots in order to be armed against them, and much more.” Galston also believed that music students would benefit from experiencing these interpretive journeys that all great artists struggled through before realizing a powerful and suitably expressive interpretation.</p>
         
         <p>In his breakthrough publication, Studienbuch, Galston offers the world of piano pedagogy the first guide to teaching musical interpretation. By documenting an artist’s thought processes while examining several of the tenets of the piano literature, Galston leads his readers through the mind of an interpreter as he analyzes the various motives, phrases, and musical nuances of Bach, Beethoven, Chopin, Liszt, and Brahms. By following Galston through his own study of selected musical works, students can learn to approach a new composition more intelligently by thinking about passages in different ways and considering a multitude of options. </p>

--- a/src/pages/galston/music-pedagogy.js
+++ b/src/pages/galston/music-pedagogy.js
@@ -57,7 +57,7 @@ const StudienbuchPage = () => (
 
 
     <section className="exhibits-section">
-      <div>
+      <div className="confessions">
         <h2>‘Confessions’</h2>
         <p>In a 1912 review of the newly published Studienbuch, Leonard Liebling described how “Gottfried Galston branches out into a new field of musico-literary endeavor, and gives a detailed record of his interpretations, with the reasons for the things he does, and the experiences and impressions undergone at the piano during his preparation of the five tremendous programs.” Liebling goes on to convey the unique value of Galston’s work by describing how, “these ‘confessions’ of Galston are to me the most interesting notes ever published on the art of piano playing, and if Liszt and Rubinstein had possessed sufficient moral courage to be as candid with their contemporaries as Galston is with his twentieth century confreres, the two masters would have left behind them a far truer picture of themselves and of their art than is contained in the newspapers of their day and in the books written about them by others.” </p>
       </div>

--- a/src/pages/galston/music-pedagogy.js
+++ b/src/pages/galston/music-pedagogy.js
@@ -11,22 +11,17 @@ const StudienbuchPage = () => (
     <h1>Significance of the book in music pedagogy</h1>
     <section className="exhibits-section">
       <div>
-        <h2>[Section Title] Lipsum lorem</h2>
+        <h2>Gift to musicians</h2>
         <p>Galston’s musical interpretations established the young pianist as one of the most gifted and sensitive interpreters of his day, but his gift to the musical world during this time was not limited to his inspired interpretations. In the spirit of scholarship and a willingness to share his musical ideas with future generations of pianists, Galston published his journey through his interpretative processes by analyzing the composers’ texts to capture, as one reviewer put it, the true character of each work. Therein lies the birth of Studienbuch, Galston's unparalleled gift to musicians and pedagogues for generations to come. </p>
       </div>
       <div>
-        <Yith id="studienbuch-notes-1"
-              mode="comparison">
-          <a className="yith-expand" href="#">Galston</a>
-          <div className="yith-structure">
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/103"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/104"></figure>
-          </div>
-        </Yith>
+      <Yith id="studienbuch-present-test"
+          mode="present">
+      <div className="yith-structure">
+        <figure className="yith-manifest"
+                data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/701"></figure>
+      </div>
+    </Yith>
       </div>
     </section>
 
@@ -44,18 +39,19 @@ const StudienbuchPage = () => (
 
     <section className="exhibits-section">
       <div>
-        <Yith id="galston-notes-2"
-              mode="present">
-          <div className="yith-structure">
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
-            ></figure>
-          </div>
-        </Yith>
+      <Yith id="studienbuch-present-test"
+          mode="present">
+      <div className="yith-structure">
+        <figure className="yith-manifest"
+                data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/322"></figure>
+      </div>
+    </Yith>
       </div>
       <div>
-        <h2>[Section Title] Lipsum lorem</h2>
-        <p>In the foreword to Galston’s Studienbuch, the author describes the musical journey every interpreter takes when learning a new work. He explains how “every thoughtful artist experiences a whole world of emotions, forms perceptions and makes decisions, finds and defines the points of attack, discovers hidden pivotal points around which the entire work turns, secretly identifies the treacherous spots in order to be armed against them, and much more.” Galston also believed that music students would benefit from experiencing these interpretive journeys that all great artists struggled through before realizing a powerful and suitably expressive interpretation. In his breakthrough publication, Studienbuch, Galston offers the world of piano pedagogy the first guide to teaching musical interpretation. By documenting an artist’s thought processes while examining several of the tenets of the piano literature, Galston leads his readers through the mind of an interpreter as he analyzes the various motives, phrases, and musical nuances of Bach, Beethoven, Chopin, Liszt, and Brahms. By following Galston through his own study of selected musical works, students can learn to approach a new composition more intelligently by thinking about passages in different ways and considering a multitude of options. </p>
+        <h2>Musicial interpretation</h2>
+        <p>In the foreword to Galston’s Studienbuch, the author describes the musical journey every interpreter takes when learning a new work. He explains how “every thoughtful artist experiences a whole world of emotions, forms perceptions and makes decisions, finds and defines the points of attack, discovers hidden pivotal points around which the entire work turns, secretly identifies the treacherous spots in order to be armed against them, and much more.” Galston also believed that music students would benefit from experiencing these interpretive journeys that all great artists struggled through before realizing a powerful and suitably expressive interpretation.</p>
+        
+        <p>In his breakthrough publication, Studienbuch, Galston offers the world of piano pedagogy the first guide to teaching musical interpretation. By documenting an artist’s thought processes while examining several of the tenets of the piano literature, Galston leads his readers through the mind of an interpreter as he analyzes the various motives, phrases, and musical nuances of Bach, Beethoven, Chopin, Liszt, and Brahms. By following Galston through his own study of selected musical works, students can learn to approach a new composition more intelligently by thinking about passages in different ways and considering a multitude of options. </p>
       </div>
     </section>
 
@@ -67,18 +63,7 @@ const StudienbuchPage = () => (
       </div>
       <div>
         <div>
-          <Yith id="galston-notes-3"
-                mode="comparison">
-            <a className="yith-expand" href="#">Galston</a>
-            <div className="yith-structure">
-              <figure className="yith-manifest"
-                      data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                      data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/153"></figure>
-              <figure className="yith-manifest"
-                      data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                      data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/154"></figure>
-            </div>
-          </Yith>
+        
         </div>
       </div>
     </section>

--- a/src/sass/components/yith.scss
+++ b/src/sass/components/yith.scss
@@ -11,6 +11,7 @@
 @import "yith/layout/comparison";
 @import "yith/layout/present";
 @import "yith/layout/projection";
+@import "yith/layout/music-pedagogy";
 
 
 .yith {

--- a/src/sass/components/yith/layout/_music-pedagogy.scss
+++ b/src/sass/components/yith/layout/_music-pedagogy.scss
@@ -18,12 +18,14 @@ section.exhibits-section .exhibits-blockquote {
   }
 }
 
-h2 {
-  margin-bottom: 0;
-}
+.gift-to-musicians, .musical-interpretation, .confessions {
+  h2 {
+    margin-bottom: 0;
+  }
 
-p {
-  margin-top: 0.5em;
+  p {
+    margin-top: 0.5em;
+  }
 }
 
 .yith-figure .yith-figure--preview .yith-figure--preview--inner a img, .yith-figure .yith-figure--preview .yith-figure--preview--inner a:visited img {

--- a/src/sass/components/yith/layout/_music-pedagogy.scss
+++ b/src/sass/components/yith/layout/_music-pedagogy.scss
@@ -1,0 +1,27 @@
+.yith-figure figcaption p {
+  display: none;
+}
+
+.yith figure figcaption {
+  strong {
+    display: block;
+  }
+}
+
+section.exhibits-section .exhibits-blockquote {
+  padding: 0 2em;
+  margin: 0 2em 2em 2em;
+
+  blockquote {
+    padding: 0;
+    margin: 0;
+  }
+}
+
+h2 {
+  margin-bottom: 0;
+}
+
+p {
+  margin-top: 0.5em;
+}

--- a/src/sass/components/yith/layout/_music-pedagogy.scss
+++ b/src/sass/components/yith/layout/_music-pedagogy.scss
@@ -28,7 +28,4 @@ section.exhibits-section .exhibits-blockquote {
   }
 }
 
-.yith-figure .yith-figure--preview .yith-figure--preview--inner a img, .yith-figure .yith-figure--preview .yith-figure--preview--inner a:visited img {
-  max-height: 400px;
-}
 

--- a/src/sass/components/yith/layout/_music-pedagogy.scss
+++ b/src/sass/components/yith/layout/_music-pedagogy.scss
@@ -25,3 +25,8 @@ h2 {
 p {
   margin-top: 0.5em;
 }
+
+.yith-figure .yith-figure--preview .yith-figure--preview--inner a img, .yith-figure .yith-figure--preview .yith-figure--preview--inner a:visited img {
+  max-height: 400px;
+}
+


### PR DESCRIPTION
**JIRA Issue**: [EXHIBIT-53](https://jirautk.atlassian.net/browse/EXHIBIT-53)

What does this do?
==================

This branch addresses the sub-tasks in EXHIBIT-53, including adjustments to the whitespace surrounding headers and blockquote, the Yith bug concerning the middle image (manifest summary null), breaking apart heavy paragraph text, and removing the image description from Figure on the Music Pedagogy page.

How should this be reviewed?
============================

It would be helpful here to double check that my changes are isolated to the Music Pedagogy page.


Additional notes:
=================

Music Pedagogy still needs a third and final image that is currently being digitized.

