### PR TITLE
Fix hardcoded IDs that conflict confused on https://github.com/utkdigitalinitiatives/exhibits/pull/15

### DIFF
--- a/src/pages/galston/concert-programs.js
+++ b/src/pages/galston/concert-programs.js
@@ -130,7 +130,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-9"
               mode="comparison">
           <a className="yith-expand" href="#">December 7, 1919</a>
           <div className="yith-structure">
@@ -143,7 +143,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-10"
               mode="comparison">
           <a className="yith-expand" href="#">December 14, 1919</a>
           <div className="yith-structure">
@@ -156,7 +156,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-11"
               mode="comparison">
           <a className="yith-expand" href="#">January 4, 1920</a>
           <div className="yith-structure">
@@ -169,7 +169,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-12"
               mode="comparison">
           <a className="yith-expand" href="#">January 11, 1920</a>
           <div className="yith-structure">
@@ -182,7 +182,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-13"
               mode="comparison">
           <a className="yith-expand" href="#">January 18, 1920</a>
           <div className="yith-structure">
@@ -195,7 +195,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-14"
               mode="comparison">
           <a className="yith-expand" href="#">January 25, 1920</a>
           <div className="yith-structure">
@@ -208,7 +208,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-15"
               mode="comparison">
           <a className="yith-expand" href="#">February 1, 1920</a>
           <div className="yith-structure">
@@ -221,7 +221,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-16"
               mode="comparison">
           <a className="yith-expand" href="#">February 8, 1920</a>
           <div className="yith-structure">
@@ -234,7 +234,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-17"
               mode="comparison">
           <a className="yith-expand" href="#">February 15, 1920</a>
           <div className="yith-structure">
@@ -247,7 +247,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-18"
               mode="comparison">
           <a className="yith-expand" href="#">February 22, 1920</a>
           <div className="yith-structure">
@@ -260,7 +260,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-19"
               mode="comparison">
           <a className="yith-expand" href="#">February 29, 1920</a>
           <div className="yith-structure">
@@ -273,7 +273,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-20"
               mode="comparison">
           <a className="yith-expand" href="#">March 7, 1920</a>
           <div className="yith-structure">
@@ -286,7 +286,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-21"
               mode="comparison">
           <a className="yith-expand" href="#">March 14, 1920</a>
           <div className="yith-structure">
@@ -299,7 +299,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-22"
               mode="comparison">
           <a className="yith-expand" href="#">March 21, 1920</a>
           <div className="yith-structure">
@@ -312,7 +312,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-23"
               mode="comparison">
           <a className="yith-expand" href="#">March 28, 1920</a>
           <div className="yith-structure">
@@ -325,7 +325,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-24"
               mode="comparison">
           <a className="yith-expand" href="#">April 4, 1920</a>
           <div className="yith-structure">
@@ -338,7 +338,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-25"
               mode="comparison">
           <a className="yith-expand" href="#">April 11, 1920</a>
           <div className="yith-structure">
@@ -351,7 +351,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-26"
               mode="comparison">
           <a className="yith-expand" href="#">April 18, 1920</a>
           <div className="yith-structure">
@@ -364,7 +364,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-27"
               mode="comparison">
           <a className="yith-expand" href="#">April 25, 1920</a>
           <div className="yith-structure">
@@ -377,7 +377,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-28"
               mode="comparison">
           <a className="yith-expand" href="#">May 2, 1920</a>
           <div className="yith-structure">
@@ -390,7 +390,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-29"
               mode="comparison">
           <a className="yith-expand" href="#">May 9, 1920</a>
           <div className="yith-structure">
@@ -403,7 +403,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-30"
               mode="comparison">
           <a className="yith-expand" href="#">May 16, 1920</a>
           <div className="yith-structure">
@@ -416,7 +416,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-31"
               mode="comparison">
           <a className="yith-expand" href="#">September 12, 1920</a>
           <div className="yith-structure">
@@ -429,7 +429,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-32"
               mode="comparison">
           <a className="yith-expand" href="#">September 26, 1920</a>
           <div className="yith-structure">
@@ -442,7 +442,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-33"
               mode="comparison">
           <a className="yith-expand" href="#">October 10, 1920</a>
           <div className="yith-structure">
@@ -455,7 +455,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-34"
               mode="comparison">
           <a className="yith-expand" href="#">October 31, 1920</a>
           <div className="yith-structure">
@@ -468,7 +468,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-35"
               mode="comparison">
           <a className="yith-expand" href="#">November 21, 1920</a>
           <div className="yith-structure">
@@ -481,7 +481,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-36"
               mode="comparison">
           <a className="yith-expand" href="#">Deceember 5, 1920</a>
           <div className="yith-structure">
@@ -494,7 +494,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-37"
               mode="comparison">
           <a className="yith-expand" href="#">January 16, 1921</a>
           <div className="yith-structure">
@@ -507,7 +507,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-38"
               mode="comparison">
           <a className="yith-expand" href="#">January 30, 1921</a>
           <div className="yith-structure">
@@ -520,7 +520,7 @@ const ConcertProgramsPage = () => (
           </div>
         </Yith>
 
-        <Yith id="concert-programs-comparison-8"
+        <Yith id="concert-programs-comparison-39"
               mode="comparison">
           <a className="yith-expand" href="#">February 13, 1921</a>
           <div className="yith-structure">
@@ -532,8 +532,8 @@ const ConcertProgramsPage = () => (
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481"></figure>
           </div>
         </Yith>
-        
-        <Yith id="concert-programs-comparison-8"
+
+        <Yith id="concert-programs-comparison-40"
               mode="comparison">
           <a className="yith-expand" href="#">February 20, 1921</a>
           <div className="yith-structure">


### PR DESCRIPTION
**JIRA Issue**: [EXHIBIT-52](https://jirautk.atlassian.net/browse/EXHIBIT-52)

What does this do?
==================

There was a conflict when approving and merging https://github.com/utkdigitalinitiatives/exhibits/pull/15 at https://github.com/utkdigitalinitiatives/exhibits/pull/15/commits/f3afd4dceaecfd5d074d59bd04b307be61e09583. I dropped the unique IDs somehow. This PR fixes that issue and adds those hardcoded IDs.
