### PR TITLE
Address EXHIBIT-78

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-lazyload": "^3.2.0",
     "react-scroll": "^1.8.2",
     "react-scrolling-nav": "^1.1.5",
-    "react-sticky-el": "^2.0.9"
+    "react-sticky-el": "^2.0.9",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "prettier": "2.2.1"

--- a/src/components/yith/Comparison.js
+++ b/src/components/yith/Comparison.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Mirador from "./Mirador";
 import _ from "lodash"
+import { v4 as uuid } from "uuid"
 
 class Comparison extends Component {
 
@@ -9,6 +10,7 @@ class Comparison extends Component {
 
     this.state ={
       windows: [0],
+      uuid: uuid(),
       activeWindows: [
         {
           manifestId: this.props.sequence[0].manifest,
@@ -116,7 +118,10 @@ class Comparison extends Component {
             <div className="yith-modal--inner">
               <Mirador
                 config={{
-                  id: 'yith-mirador-default',
+                  id: `yith-mirador-${this.state.uuid}}`,
+                  createGenerateClassNameOptions: { // Options passed directly to createGenerateClassName in Material-UI https://material-ui.com/styles/api/#creategenerateclassname-options-class-name-generator
+                    productionPrefix: `mirador-${this.state.uuid}`,
+                  },
                   window: {
                     hideWindowTitle: false,
                     sideBarOpen: false,

--- a/src/components/yith/Comparison.js
+++ b/src/components/yith/Comparison.js
@@ -118,7 +118,7 @@ class Comparison extends Component {
             <div className="yith-modal--inner">
               <Mirador
                 config={{
-                  id: `yith-mirador-${this.state.uuid}}`,
+                  id: `yith-mirador-${this.state.uuid}`,
                   createGenerateClassNameOptions: { // Options passed directly to createGenerateClassName in Material-UI https://material-ui.com/styles/api/#creategenerateclassname-options-class-name-generator
                     productionPrefix: `mirador-${this.state.uuid}`,
                   },

--- a/src/components/yith/Modal.js
+++ b/src/components/yith/Modal.js
@@ -9,7 +9,8 @@ class Modal extends Component {
     super(props);
 
     this.state = {
-      loaded: false
+      loaded: false,
+      uuid: uuid()
     }
 
     this.showModal = this.showModal.bind(this);
@@ -43,9 +44,9 @@ class Modal extends Component {
         <div className="yith-modal">
           <Mirador
             config={{
-              id: `yith-mirador-${uuid()}`,
+              id: `yith-mirador-${this.state.uuid}}`,
               createGenerateClassNameOptions: { // Options passed directly to createGenerateClassName in Material-UI https://material-ui.com/styles/api/#creategenerateclassname-options-class-name-generator
-                productionPrefix: `mirador-${uuid()}`,
+                productionPrefix: `mirador-${this.state.uuid}`,
               },
               window: {
                 hideWindowTitle: false,

--- a/src/components/yith/Modal.js
+++ b/src/components/yith/Modal.js
@@ -44,7 +44,7 @@ class Modal extends Component {
         <div className="yith-modal">
           <Mirador
             config={{
-              id: `yith-mirador-${this.state.uuid}}`,
+              id: `yith-mirador-${this.state.uuid}`,
               createGenerateClassNameOptions: { // Options passed directly to createGenerateClassName in Material-UI https://material-ui.com/styles/api/#creategenerateclassname-options-class-name-generator
                 productionPrefix: `mirador-${this.state.uuid}`,
               },

--- a/src/components/yith/Modal.js
+++ b/src/components/yith/Modal.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Mirador from "./Mirador";
+import { v4 as uuid } from 'uuid';
 import _ from "lodash"
 
 class Modal extends Component {
@@ -42,7 +43,7 @@ class Modal extends Component {
         <div className="yith-modal">
           <Mirador
             config={{
-              id: `yith-mirador`,
+              id: `yith-mirador-${uuid()}`,
               window: {
                 hideWindowTitle: false,
                 sideBarOpen: true,

--- a/src/components/yith/Modal.js
+++ b/src/components/yith/Modal.js
@@ -44,6 +44,9 @@ class Modal extends Component {
           <Mirador
             config={{
               id: `yith-mirador-${uuid()}`,
+              createGenerateClassNameOptions: { // Options passed directly to createGenerateClassName in Material-UI https://material-ui.com/styles/api/#creategenerateclassname-options-class-name-generator
+                productionPrefix: `mirador-${uuid()}`,
+              },
               window: {
                 hideWindowTitle: false,
                 sideBarOpen: true,

--- a/src/components/yith/Projection.js
+++ b/src/components/yith/Projection.js
@@ -166,7 +166,7 @@ class Projection extends Component {
     return (
       <Mirador
         config={{
-          id: `yith-mirador-${this.state.uuid}}`,
+          id: `yith-mirador-${this.state.uuid}`,
           createGenerateClassNameOptions: { // Options passed directly to createGenerateClassName in Material-UI https://material-ui.com/styles/api/#creategenerateclassname-options-class-name-generator
             productionPrefix: `mirador-${this.state.uuid}`,
           },

--- a/src/components/yith/Projection.js
+++ b/src/components/yith/Projection.js
@@ -13,7 +13,8 @@ class Projection extends Component {
       activeWindow: null,
       slideMode: 'initial',
       minimized: false,
-      contextLayout: 'default'
+      contextLayout: 'default',
+      uuid: uuid()
     }
 
     this.showModal = this.showModal.bind(this);
@@ -164,7 +165,10 @@ class Projection extends Component {
     return (
       <Mirador
         config={{
-          id: 'yith-projection',
+          id: `yith-mirador-${this.state.uuid}}`,
+          createGenerateClassNameOptions: { // Options passed directly to createGenerateClassName in Material-UI https://material-ui.com/styles/api/#creategenerateclassname-options-class-name-generator
+            productionPrefix: `mirador-${this.state.uuid}`,
+          },
           selectedTheme: 'dark',
           window: {
             hideWindowTitle: true,

--- a/src/components/yith/Projection.js
+++ b/src/components/yith/Projection.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Mirador from "./Mirador";
+import { v4 as uuid } from "uuid"
 
 class Projection extends Component {
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13801,7 +13801,7 @@ uuid@3.4.0, uuid@^3.0.0, uuid@^3.0.1, uuid@^3.2.1, uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.1.0:
+uuid@^8.1.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
**JIRA Issue**: [EXHIBIT-78](https://jirautk.atlassian.net/browse/EXHIBIT-78)

What does this do?
==================

Fixes issue in production where multiple opens of various mirador instances caused the viewer to appear mangled. This issue was determined to be strictly related to how classes and corresponding inline styling is built on the fly for a mirador instance. The first Mirador instance (A) might have a class `.mirador-60` that defined a wrapping element in the OSD controls while a second Mirador instance (B) might have that same class selector used for an entirely different element in the structure. To work around this, I have added uuid's to the class structure of each unique instance of a Yith component. The mirador instantiation occurs in three different files and this logic was added to the class structure prefixing for all.

![image](https://user-images.githubusercontent.com/7376450/128912014-b4292051-a2ea-48de-8ca3-a29ba18f0fbb.png)

How should this be reviewed?
============================

The easiest way to review this is to visit the sample site at https://deploy-preview-19--utk-exhibits.netlify.app/sample/ and click in and out of multiple Yith components rendered on screen. At no point should the viewer be mangled like it currently is on https://utk-exhibits.netlify.app/sample/.

![image](https://user-images.githubusercontent.com/7376450/128912194-83287fa4-00b1-4068-b88f-6f9900af0e1d.png)

Additional notes:
=================

The chronology component does have an unrelated z-index issue that needs to be resolved. This only occurs on the homepage of https://utk-exhibits.netlify.app/sample/ when the chronology items at the bottom are expanded.
