### PR TITLE
Rotate the page descibed in the Musical Interpretation Yith presentat…

### DIFF
--- a/src/pages/galston/music-pedagogy.js
+++ b/src/pages/galston/music-pedagogy.js
@@ -49,7 +49,8 @@ const StudienbuchPage = () => (
           mode="present">
       <div className="yith-structure">
         <figure className="yith-manifest"
-                data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/949"></figure>
+                data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/949"
+                data-region="1136,232,6000,3920"></figure>
       </div>
     </Yith>
       </div>

--- a/src/pages/galston/music-pedagogy.js
+++ b/src/pages/galston/music-pedagogy.js
@@ -49,7 +49,7 @@ const StudienbuchPage = () => (
           mode="present">
       <div className="yith-structure">
         <figure className="yith-manifest"
-                data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/322"></figure>
+                data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/949"></figure>
       </div>
     </Yith>
       </div>


### PR DESCRIPTION
**JIRA Issue**: [EXHIBIT-82](https://jirautk.atlassian.net/browse/EXHIBIT-82)

What does this do?
==================

Rotates the `Studienbuch : page 260` image in Galston 270 degrees.  I rotated the original JP2, converted to a tiff, and uploaded as a large image with metadata from the book.  It is inactive to keep it out of other things.

How should this be reviewed?
============================

Look at the Music pedagogy page on netlify.  Does it look good.

Additional notes:
=================

Have we thought about cropping for Yith presents?  Does that need to be done here?