### PR TITLE
Exhibit 83

### DIFF
--- a/src/pages/galston/resources.js
+++ b/src/pages/galston/resources.js
@@ -109,7 +109,7 @@ const ResourcesPage = () => (
             Cassirer collection, M0287, Dept. of Special Collections, Stanford
             University Libraries, Stanford, California.{" "}
             <a href="https://oac.cdlib.org/findaid/ark:/13030/tf538nb0pb/">
-              https://oac.cdlib.org/findaid/ark:/13030/tf538nb0pb/
+              https://oac.cdlib.org/findaid/ark:/13030/tf538nb0pb/ 
             </a>
             This collection provides more context about Cassirer, the publisher
             of the first edition of Galston's{" "}

--- a/src/sass/entity/galston/_resources.scss
+++ b/src/sass/entity/galston/_resources.scss
@@ -68,7 +68,7 @@
       margin-right: 3rem;
 
       a {
-        color: #B9E1E2;
+        color: white;
       }
     }
   }


### PR DESCRIPTION
**JIRA Issue**: [EXHIBIT-83](https://jirautk.atlassian.net/browse/EXHIBIT-83)

What does this do?
==================

This adds a back gradient panel to break up the Resources page and add some visual interest, following Mat's design on the homepage and using colors from the chronology.

How should this be reviewed?
============================

Test Resources page in the Netlify preview.

Additional notes:
=================

I'll want the group's feedback on this, but I've spent the allotted 2h on this part.
