### PR TITLE
Address EXHIBIT-81 (Comparison Annotation Zoom)

### DIFF
--- a/src/components/yith/Comparison.js
+++ b/src/components/yith/Comparison.js
@@ -46,8 +46,8 @@ class Comparison extends Component {
     for (const index of this.state.windows) {
       active.push(
         {
-          manifestId: this.props.sequence[index].manifest,
-          canvasId: this.props.sequence[index].canvas
+          manifestId: this.state.sequence[index].manifestId,
+          canvasId: this.state.sequence[index].canvasId
         }
       )
     }

--- a/src/components/yith/Comparison.js
+++ b/src/components/yith/Comparison.js
@@ -85,6 +85,16 @@ class Comparison extends Component {
     })
   }
 
+  determineRegions = () => {
+    return this.state.activeWindows.map((window, index) => {
+      let region = null
+      if (typeof this.state.sequence[index].region !== 'undefined') {
+        region = this.state.sequence[index].region
+      }
+      return region
+    });
+  }
+
   getAnnotationById = (id, manifest) => {
     let data = null
     if (manifest) {
@@ -180,6 +190,7 @@ class Comparison extends Component {
                   },
                 }}
                 plugins={[]}
+                regions={this.determineRegions()}
                 mode="nextManifest"
               />
             </div>

--- a/src/components/yith/Comparison.js
+++ b/src/components/yith/Comparison.js
@@ -11,22 +11,8 @@ class Comparison extends Component {
     this.state ={
       windows: [0],
       uuid: uuid(),
-      activeWindows: [
-        {
-          manifestId: this.props.sequence[0].manifest,
-          canvasId: this.props.sequence[0].canvas
-        }
-      ],
-      sequence: [
-        {
-          manifestId: this.props.sequence[0].manifest,
-          canvasId: this.props.sequence[0].canvas
-        },
-        {
-          manifestId: this.props.sequence[1].manifest,
-          canvasId: this.props.sequence[1].canvas
-        }
-      ],
+      activeWindows: [],
+      sequence: [],
       data: []
     }
 
@@ -96,6 +82,51 @@ class Comparison extends Component {
           </figure>
         </a>
       )
+    })
+  }
+
+  getAnnotationById = (id, manifest) => {
+    let data = null
+    if (manifest) {
+      manifest.items.map((canvas, canvasIndex) => {
+        if (canvas.annotations) {
+          return canvas.annotations[0].items.map((annotation, annotationIndex) => {
+            if (annotation.id === id) {
+              let target = annotation.target.split('#xywh=');
+              data = {}
+              data.canvasId = target[0];
+              data.region = target[1];
+            }
+          });
+        }
+      });
+    }
+    return data
+  }
+
+  componentDidMount() {
+    const { sequence } = this.props
+    const items = sequence.map((item, index) => {
+      if (item.type === 'manifest') {
+        return {
+          manifestId: item.manifest,
+          canvasId: item.canvas
+        }
+      } else if (item.type === 'annotation') {
+        const data = this.getAnnotationById(item.annotation, this.props.data[index])
+        if (typeof data === 'object') {
+          return {
+            manifestId: item.manifest,
+            canvasId: data.canvasId,
+            region: data.region
+          }
+        }
+      }
+    })
+
+    this.setState({
+      activeWindows: [items[0]],
+      sequence: items
     })
   }
 

--- a/src/components/yith/Mode.js
+++ b/src/components/yith/Mode.js
@@ -76,26 +76,28 @@ class Mode extends Component {
   }
 
   renderStructure = (structure, active, mode) => {
-    if (mode === 'chronology') {
-      return (
-        <Chronology sequence={this.state.sequence} description={this.props.description}  />
-      )
-    } else if (mode === 'comparison') {
-      return (
-        <div className={`yith-modal-wrapper yith-modal-${active}`}>
-          <Comparison data={this.state.data} sequence={this.state.sequence} active={active} showModal={this.showModal}  />
-        </div>
-      )
-    } else if (mode === 'present') {
-      return (
-        <Present sequence={this.state.sequence} />
-      )
-    } else if (mode === 'projection' && this.state.data.length > 0) {
-      return (
-        <div className={`yith-modal-wrapper yith-modal-${active}`}>
-          <Projection manifests={this.state.data} sequence={this.state.sequence} active={active} showModal={this.showModal} />
-        </div>
-      )
+    if (this.state.data.length === structure.length) {
+      if (mode === 'chronology') {
+        return (
+          <Chronology sequence={this.state.sequence} description={this.props.description}  />
+        )
+      } else if (mode === 'comparison') {
+        return (
+          <div className={`yith-modal-wrapper yith-modal-${active}`}>
+            <Comparison data={this.state.data} sequence={this.state.sequence} active={active} showModal={this.showModal}  />
+          </div>
+        )
+      } else if (mode === 'present') {
+        return (
+          <Present sequence={this.state.sequence} />
+        )
+      } else if (mode === 'projection') {
+        return (
+          <div className={`yith-modal-wrapper yith-modal-${active}`}>
+            <Projection manifests={this.state.data} sequence={this.state.sequence} active={active} showModal={this.showModal} />
+          </div>
+        )
+      }
     }
   }
 
@@ -108,7 +110,11 @@ class Mode extends Component {
     })
       .then(response => response.json())
       .then((data) => {
-        this.state.data[index] = data
+        let currentData = this.state.data
+        currentData[index] = data
+        this.setState({
+          data: currentData
+        })
       })
       .catch(err => console.error(this.props.url, err.toString()));
     return null

--- a/src/components/yith/Present.js
+++ b/src/components/yith/Present.js
@@ -18,8 +18,6 @@ class Present extends Component {
       autozoom = sequence[0].autozoom
     }
 
-    console.log(sequence)
-
     return (
       <div className="yith-structure">
         <div className={sequence[0].class}>

--- a/src/components/yith/Projection.js
+++ b/src/components/yith/Projection.js
@@ -15,7 +15,8 @@ class Projection extends Component {
       slideMode: 'initial',
       minimized: false,
       contextLayout: 'default',
-      uuid: uuid()
+      uuid: uuid(),
+      region: null
     }
 
     this.showModal = this.showModal.bind(this);
@@ -31,7 +32,7 @@ class Projection extends Component {
       index: 0,
       loaded: false,
       autozoom: false,
-      region: null,
+      regions: null,
       interaction: 'toggle',
       slideMode: 'initial'
     });
@@ -163,6 +164,7 @@ class Projection extends Component {
   }
 
   getMirador = () => {
+    console.log(this.state.region)
     return (
       <Mirador
         config={{
@@ -186,8 +188,7 @@ class Projection extends Component {
         }}
         plugins={[]}
         manifest={this.props.sequence[this.state.index].manifest}
-        autozoom={this.state.autozoom}
-        region={this.state.region}
+        regions={[this.state.region]}
         mode={this.state.slideMode}
       />
     )

--- a/src/components/yith/Yith.js
+++ b/src/components/yith/Yith.js
@@ -80,8 +80,13 @@ class Yith extends Component {
 
       if (el.props.children !== undefined) {
         if (typeof el.props.children === 'object') {
+
           if (el.props.children.type === 'div' && el.props.children.props.class === 'yith-items') {
+
             let annotations = el.props.children.props.children
+            if (!Array.isArray(el.props.children.props.children)) {
+              annotations = [el.props.children.props.children]
+            }
 
             annotationsStructure = annotations.map(function (aEl) {
 

--- a/src/pages/sample/comparison-refactor.js
+++ b/src/pages/sample/comparison-refactor.js
@@ -23,7 +23,7 @@ const ComparisonRefactor = () => (
                     data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
-                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/annotations/1">
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/1">
                   <figcaption>
                     <strong>string</strong>
                     <p>string</p>

--- a/src/pages/sample/comparison-refactor.js
+++ b/src/pages/sample/comparison-refactor.js
@@ -15,13 +15,22 @@ const ComparisonRefactor = () => (
               mode="comparison">
           <a className="yith-expand" href="#">October 12, 1919</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="98,760,3198,4511"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/8"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/annotations/1">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
       </div>

--- a/src/pages/sample/comparison-refactor.js
+++ b/src/pages/sample/comparison-refactor.js
@@ -1,0 +1,53 @@
+import * as React from "react"
+import { Link } from "gatsby"
+
+import Layout from "../../components/layout"
+import Seo from "../../components/seo"
+import Yith from "../../components/yith/Yith"
+
+const ComparisonRefactor = () => (
+  <Layout exhibit="sample">
+    <Seo title="Comparison: Sample Exhibit" />
+
+    <section className="exhibits-section">
+      <div>
+        <Yith id="concert-programs-comparison-1"
+              mode="comparison">
+          <a className="yith-expand" href="#">October 12, 1919</a>
+          <div className="yith-structure">
+            <figure className="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
+                    data-region="98,760,3198,4511"
+                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/8"></figure>
+            <figure className="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
+                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477"></figure>
+          </div>
+        </Yith>
+      </div>
+      <div>
+        <h2>Tourism and Commerce</h2>
+        <p>
+          Sed vitae dui ut urna suscipit lobortis id ac magna. Donec velit ex,
+          dapibus a maximus vel, feugiat vel lacus. Maecenas maximus, lorem in
+          aliquet ultricies, nisi metus tincidunt ligula, eget viverra massa
+          metus at sapien. Ut ullamcorper id mauris luctus maximus. Nulla
+          maximus lectus dui. Phasellus blandit tristique sem. Etiam et ex vel
+          metus mattis rutrum.
+        </p>
+        <p>
+          Cras condimentum ornare velit, nec malesuada augue efficitur a. Donec
+          mi orci, eleifend eget laoreet sit amet, consectetur in quam. Vivamus
+          eleifend nunc nec ante porta, et consequat est semper. Aliquam
+          ullamcorper dui quis diam mollis, sed posuere est efficitur.
+        </p>
+        <p>
+          Duis finibus dui lectus, id aliquam dolor ornare eu. Curabitur ut
+          pellentesque nisi, at pretium odio.
+        </p>
+      </div>
+    </section>
+  </Layout>
+)
+
+export default ComparisonRefactor


### PR DESCRIPTION
**JIRA Issue**: [EXHIBIT-81](https://jirautk.atlassian.net/browse/EXHIBIT-81)

What does this do?
==============

This pull request adds functionality to a `<Comparison/>` component allowing it derive the canvas and zoomable region from an annotation ID. Previously the component required a set canvas ID using a `data-canvas` attribute. To build add this, we brought in functionality already existing in the `<Projection/>` component. In the process we also changed how the `<Mirador/>` component receives region props, allowing the region prop to be associated with an activeWindow index. This was necessary as the `<Comparison/>` component will always have two available windows and we may not know which, or if any window has an associated region to zoom on.

How should this be reviewed?
======================

Review https://deploy-preview-27--utk-exhibits.netlify.app/sample/comparison-refactor/ and test.
