### PR TITLE
Address EXHIBIT-93.

### DIFF
--- a/src/pages/galston/concert-programs.js
+++ b/src/pages/galston/concert-programs.js
@@ -627,13 +627,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">April 25, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="263,623,4685,6746"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/114"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/1">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -641,13 +650,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">May 2, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="440,680,4800,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/118"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/2">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -655,13 +673,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">May 9, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="392,552,4896,6656"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/122"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/3">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -669,13 +696,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">May 16, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="368,616,4832,6672"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/126"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/4">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -683,13 +719,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">September 12, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="264,536,4896,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/130"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/5">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -697,13 +742,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">September 26, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="224,584,4912,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/134"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/6">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -711,13 +765,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">October 10, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="352,560,4864,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/138"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/7">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -725,13 +788,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">October 31, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="296,528,4880,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/142"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/8">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 

--- a/src/pages/galston/concert-programs.js
+++ b/src/pages/galston/concert-programs.js
@@ -213,13 +213,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">December 7, 1919</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="264,528,4816,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/42"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/1">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -227,13 +236,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">December 14, 1919</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="312,464,4800,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/46"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/2">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -241,13 +259,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">January 4, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="232,512,4880,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/50"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/3">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -255,13 +282,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">January 11, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="256,552,4896,6688"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/54"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/4">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -269,13 +305,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">January 18, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="392,512,4816,6672"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/58"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/5">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -283,13 +328,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">January 25, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="312,624,4848,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/62"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/6">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -297,13 +351,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">February 1, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="312,584,4832,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/66"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/7">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -311,13 +374,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">February 8, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="88,616,4848,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/70"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure className="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/8">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -325,13 +397,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">February 15, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="288,608,4848,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/74"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/9">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -339,13 +420,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">February 22, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="312,648,4864,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/78"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/10">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 

--- a/src/pages/galston/concert-programs.js
+++ b/src/pages/galston/concert-programs.js
@@ -32,13 +32,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">October 12, 1919</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="98,760,3198,4511"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/8"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/1">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
         <Yith id="concert-programs-comparison-2"

--- a/src/pages/galston/concert-programs.js
+++ b/src/pages/galston/concert-programs.js
@@ -811,13 +811,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">November 21, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="304,680,4880,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/146"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/1">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -825,13 +834,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">December 5, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="296,528,4864,6768"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/150"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/2">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -839,13 +857,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">January 16, 1921</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="552,576,4832,6640"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/154"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/3">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -853,13 +880,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">January 30, 1921</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="448,704,4880,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/158"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/4">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -867,13 +903,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">February 13, 1921</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="344,640,4864,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/162"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/5">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -881,13 +926,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">February 20, 1921</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="312,608,4864,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/166"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/6">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
       </div>

--- a/src/pages/galston/concert-programs.js
+++ b/src/pages/galston/concert-programs.js
@@ -76,26 +76,44 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">October 26, 1919</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="432,608,4944,6784"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/18"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/3">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
         <Yith id="concert-programs-comparison-4"
               mode="comparison">
           <a className="yith-expand" href="#">November 2, 1919</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="320,600,4992,6816"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/22"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/4">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -103,13 +121,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">November 9, 1919</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="344,336,5168,7312"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/26"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/5">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -117,13 +144,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">November 16, 1919</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="368,608,4912,6848"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/30"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/6">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -131,13 +167,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">November 23, 1919</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="176,552,4880,6896"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/34"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/7">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -145,13 +190,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">November 30, 1919</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="256,496,4864,6800"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/38"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/8">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 

--- a/src/pages/galston/concert-programs.js
+++ b/src/pages/galston/concert-programs.js
@@ -37,7 +37,7 @@ const ConcertProgramsPage = () => (
                     data-region="98,760,3198,4511"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/8"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/1">
@@ -59,7 +59,7 @@ const ConcertProgramsPage = () => (
                     data-region="304,768,5008,6640"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/14"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/2">
@@ -81,7 +81,7 @@ const ConcertProgramsPage = () => (
                     data-region="432,608,4944,6784"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/18"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/3">
@@ -103,7 +103,7 @@ const ConcertProgramsPage = () => (
                     data-region="320,600,4992,6816"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/22"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/4">
@@ -126,7 +126,7 @@ const ConcertProgramsPage = () => (
                     data-region="344,336,5168,7312"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/26"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/5">
@@ -149,7 +149,7 @@ const ConcertProgramsPage = () => (
                     data-region="368,608,4912,6848"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/30"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/6">
@@ -172,7 +172,7 @@ const ConcertProgramsPage = () => (
                     data-region="176,552,4880,6896"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/34"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/7">
@@ -195,7 +195,7 @@ const ConcertProgramsPage = () => (
                     data-region="256,496,4864,6800"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/38"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/8">
@@ -218,7 +218,7 @@ const ConcertProgramsPage = () => (
                     data-region="264,528,4816,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/42"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/1">
@@ -241,7 +241,7 @@ const ConcertProgramsPage = () => (
                     data-region="312,464,4800,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/46"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/2">
@@ -264,7 +264,7 @@ const ConcertProgramsPage = () => (
                     data-region="232,512,4880,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/50"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/3">
@@ -287,7 +287,7 @@ const ConcertProgramsPage = () => (
                     data-region="256,552,4896,6688"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/54"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/4">
@@ -310,7 +310,7 @@ const ConcertProgramsPage = () => (
                     data-region="392,512,4816,6672"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/58"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/5">
@@ -333,7 +333,7 @@ const ConcertProgramsPage = () => (
                     data-region="312,624,4848,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/62"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/6">
@@ -356,7 +356,7 @@ const ConcertProgramsPage = () => (
                     data-region="312,584,4832,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/66"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/7">
@@ -379,7 +379,7 @@ const ConcertProgramsPage = () => (
                     data-region="88,616,4848,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/70"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure className="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/8">
@@ -402,7 +402,7 @@ const ConcertProgramsPage = () => (
                     data-region="288,608,4848,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/74"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/9">
@@ -425,7 +425,7 @@ const ConcertProgramsPage = () => (
                     data-region="312,648,4864,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/78"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/10">
@@ -448,7 +448,7 @@ const ConcertProgramsPage = () => (
                     data-region="296,632,4848,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/82"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/1">
@@ -471,7 +471,7 @@ const ConcertProgramsPage = () => (
                     data-region="296,632,4848,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/86"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/2">
@@ -494,7 +494,7 @@ const ConcertProgramsPage = () => (
                     data-region="376,600,4912,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/90"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/3">
@@ -517,7 +517,7 @@ const ConcertProgramsPage = () => (
                     data-region="296,1128,4752,5872"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/94"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/4">
@@ -540,7 +540,7 @@ const ConcertProgramsPage = () => (
                     data-region="296,1128,4752,5872"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/98"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/5">
@@ -563,7 +563,7 @@ const ConcertProgramsPage = () => (
                     data-region="168,592,4896,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/102"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/6">
@@ -586,7 +586,7 @@ const ConcertProgramsPage = () => (
                     data-region="280,616,4912,6672"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/106"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/7">
@@ -609,7 +609,7 @@ const ConcertProgramsPage = () => (
                     data-region="304,664,4864,6688"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/110"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/8">
@@ -632,7 +632,7 @@ const ConcertProgramsPage = () => (
                     data-region="263,623,4685,6746"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/114"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/1">
@@ -655,7 +655,7 @@ const ConcertProgramsPage = () => (
                     data-region="440,680,4800,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/118"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/2">
@@ -678,7 +678,7 @@ const ConcertProgramsPage = () => (
                     data-region="392,552,4896,6656"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/122"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/3">
@@ -701,7 +701,7 @@ const ConcertProgramsPage = () => (
                     data-region="368,616,4832,6672"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/126"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/4">
@@ -724,7 +724,7 @@ const ConcertProgramsPage = () => (
                     data-region="264,536,4896,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/130"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/5">
@@ -747,7 +747,7 @@ const ConcertProgramsPage = () => (
                     data-region="224,584,4912,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/134"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/6">
@@ -770,7 +770,7 @@ const ConcertProgramsPage = () => (
                     data-region="352,560,4864,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/138"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/7">
@@ -793,7 +793,7 @@ const ConcertProgramsPage = () => (
                     data-region="296,528,4880,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/142"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/8">
@@ -816,7 +816,7 @@ const ConcertProgramsPage = () => (
                     data-region="304,680,4880,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/146"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/1">
@@ -839,7 +839,7 @@ const ConcertProgramsPage = () => (
                     data-region="296,528,4864,6768"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/150"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/2">
@@ -862,7 +862,7 @@ const ConcertProgramsPage = () => (
                     data-region="552,576,4832,6640"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/154"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/3">
@@ -885,7 +885,7 @@ const ConcertProgramsPage = () => (
                     data-region="448,704,4880,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/158"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/4">
@@ -908,7 +908,7 @@ const ConcertProgramsPage = () => (
                     data-region="344,640,4864,6704"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/162"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/5">
@@ -931,7 +931,7 @@ const ConcertProgramsPage = () => (
                     data-region="312,608,4864,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/166"></figure>
             <figure class="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch_not_paged.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
                         data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/6">

--- a/src/pages/galston/concert-programs.js
+++ b/src/pages/galston/concert-programs.js
@@ -40,7 +40,7 @@ const ConcertProgramsPage = () => (
                     data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
-                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/1">
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/1">
                   <figcaption>
                     <strong>string</strong>
                     <p>string</p>
@@ -62,7 +62,7 @@ const ConcertProgramsPage = () => (
                     data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
-                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/2">
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/2">
                   <figcaption>
                     <strong>string</strong>
                     <p>string</p>
@@ -84,7 +84,7 @@ const ConcertProgramsPage = () => (
                     data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
-                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/3">
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/3">
                   <figcaption>
                     <strong>string</strong>
                     <p>string</p>
@@ -106,7 +106,7 @@ const ConcertProgramsPage = () => (
                     data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
-                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/4">
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/4">
                   <figcaption>
                     <strong>string</strong>
                     <p>string</p>
@@ -129,7 +129,7 @@ const ConcertProgramsPage = () => (
                     data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
-                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/5">
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/5">
                   <figcaption>
                     <strong>string</strong>
                     <p>string</p>
@@ -152,7 +152,7 @@ const ConcertProgramsPage = () => (
                     data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
-                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/6">
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/6">
                   <figcaption>
                     <strong>string</strong>
                     <p>string</p>
@@ -175,7 +175,7 @@ const ConcertProgramsPage = () => (
                     data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
-                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/7">
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/7">
                   <figcaption>
                     <strong>string</strong>
                     <p>string</p>
@@ -198,7 +198,7 @@ const ConcertProgramsPage = () => (
                     data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
               <div class="yith-items">
                 <figure class="yith-annotation"
-                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/8">
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/8">
                   <figcaption>
                     <strong>string</strong>
                     <p>string</p>

--- a/src/pages/galston/concert-programs.js
+++ b/src/pages/galston/concert-programs.js
@@ -54,13 +54,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">October 19, 1919</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="304,768,5008,6640"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/14"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/2">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
         <Yith id="concert-programs-comparison-3"

--- a/src/pages/galston/concert-programs.js
+++ b/src/pages/galston/concert-programs.js
@@ -443,13 +443,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">February 29, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="296,632,4848,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/82"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/1">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -457,13 +466,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">March 7, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="296,632,4848,6720"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/86"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/2">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -471,13 +489,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">March 14, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="376,600,4912,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/90"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/3">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -485,13 +512,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">March 21, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="296,1128,4752,5872"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/94"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/4">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -499,13 +535,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">March 28, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="296,1128,4752,5872"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/98"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/5">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -513,13 +558,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">April 4, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="168,592,4896,6736"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/102"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/6">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -527,13 +581,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">April 11, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="280,616,4912,6672"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/106"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/7">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 
@@ -541,13 +604,22 @@ const ConcertProgramsPage = () => (
               mode="comparison">
           <a className="yith-expand" href="#">April 18, 1920</a>
           <div className="yith-structure">
-            <figure className="yith-manifest"
+            <figure class="yith-manifest"
                     data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/1"
                     data-region="304,664,4864,6688"
                     data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/1/canvas/110"></figure>
-            <figure className="yith-manifest"
-                    data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/178"
-                    data-canvas="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479"></figure>
+            <figure class="yith-manifest"
+                    data-manifest="https://digital.lib.utk.edu/static/iiif/studienbuch.json">
+              <div class="yith-items">
+                <figure class="yith-annotation"
+                        data-annotation="https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/8">
+                  <figcaption>
+                    <strong>string</strong>
+                    <p>string</p>
+                  </figcaption>
+                </figure>
+              </div>
+            </figure>
           </div>
         </Yith>
 


### PR DESCRIPTION
**JIRA Issue**: [EXHIBIT-93](https://jirautk.atlassian.net/browse/EXHIBIT-93)

What does this do?
==================

Adds corresponding Yith components for annotations / zooms in concert program comparisons.

How should this be reviewed?
============================

To review, go to galston concert programs and click on a comparison.  In the Miradora workspace, if you launch the second window, it should show open the canvas in the workspace and zoom on an annotation.

There are some gotchas and notes that I'll list below.

Additional notes:
=================

The old code that this refactors has a bunch of JSX things in it.  For some reason (at least in window 2), if this stuff persists here it will break our work.  I've tried to make sure this isn't a problem (everything is addressed), but if you are seeing canvas 1 load or display for window 2, this is most likely a JSX issue.

Another note, there is some magic related to Mirador and manifests with "paged" viewing instructions that does not work nicely with our changes to Yith comparison and projection.  For this reason, if you navigate to an annotation that appears on the page on the right, it tries to load on the page on the left.  To address, we need to get rid of the paged viewing instructions.  I'll leave as draft until this is done.
