### PR TITLE
Fix bug in music pedagogy page.

### DIFF
--- a/src/pages/galston/music-pedagogy.js
+++ b/src/pages/galston/music-pedagogy.js
@@ -148,7 +148,7 @@ const StudienbuchPage = () => {
                               mode="present">
                             <div className="yith-structure">
                                 <figure className="yith-manifest"
-                                        data-manifest="https://digital.lib.utk.edu/assemble/manifest/galston/948"></figure>
+                                        data-manifest="https://digital.lib.utk.edu/static/iiif/galston_948.json"></figure>
                             </div>
                         </Yith>
                     </div>


### PR DESCRIPTION
What does this do?
==================

Fixes the bug causing music pedagogy to fail to load.

How should this be reviewed?
============================

Review the branch and check that it builds.

Additional notes:
=================

Exhibits expects that the body of a WebAnnotation to be an array, but it should be a JSON object.  This is a temporary fix by pointing at a static manifest that changes the data type. This should have been done previously, but I guess it was missed. We never noticed because the manifest was cached.
